### PR TITLE
rewrote Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,15 +2,17 @@ CC = go
 TARGET = pipes
 bindir = /usr/local/bin
 
-all: pipes.go
+$(TARGET): *.go
 	$(CC) get -x github.com/rthornton128/goncurses
-	$(CC) build -x -o $(TARGET) pipes.go
+	$(CC) build -x -o $(TARGET) $<
 
-install: all
+.PHONY all: $(TARGET)
+
+.PHONY install: all
 	mv $(TARGET) $(DESTDIR)$(bindir)/$(TARGET)
 
-uninstall:
+.PHONY uninstall:
 	rm -f $(DESTDIR)$(bindir)/$(TARGET)
 
-clean:
+.PHONY clean:
 	rm -f $(TARGET)


### PR DESCRIPTION
Made the targets all, install, uninstall and clean phony to avoid interference with certain filesystems on certain systems (basically, the code would never even run if a file called clean or install is present which may very well be the case if some distro decides to include this in their repo). Also clean shouldn't depend on all because that will cause the file to be built only to be deleted immediately afterwards which wastes precious CPU cycles. Also, I updated the build rule itself to make it more generic